### PR TITLE
Adding past exam solutions

### DIFF
--- a/_CS132/index.md
+++ b/_CS132/index.md
@@ -65,6 +65,13 @@ points, nor are guaranteed to be correct.
 
 A document containing all of the typed solutions linked above concatenated together is available [here](worksheets/combinedTyped.pdf)
 
+## Past Exam Solutions
+
+Below are a set of student written exam solutions for the past exam papers:
+
+| Year | Answers|
+|------|--------|
+
 ## Flash Cards
 
 Here are a set of flashcards for the module by **Leon Chipchase** (they still need to be refined), and please message me if there is something incorrect on there.


### PR DESCRIPTION
Should we add past exam solutions, I have finished the 2018 past paper, but if we were able to get a question bank for solutions on past papers this would be good no? I haven't added any actual links yet, but just a suggestion if people want to contribute their answers