### PR TITLE
CS141 is not CS140

### DIFF
--- a/_CS141/index.md
+++ b/_CS141/index.md
@@ -1,6 +1,6 @@
 ---
 layout: modhome
-title: CS140 Functional Programming
+title: CS141 Functional Programming
 ---
 
 # Welcome to the CS141 revision guide


### PR DESCRIPTION
The markdown for the CS141 index page referred to CS141 as CS140, fixed in the PR.

(Michael spotted this, I just fixed it :D )