### PR TITLE
Added Algolia's Jekyll plugin to build a search index

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -19,6 +19,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
+      # Update search index
+      - name: Update search index
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API }}
+        run: |
+          bundle exec jekyll algolia
+
       # Use GitHub Deploy Action to build and deploy to Github
       - uses: helaili/jekyll-action@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "jekyll", "~> 4.2.0"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-github-metadata"
+  gem "jekyll-algolia", "~> 1.0"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -135,3 +135,7 @@ collections:
       - part1.md
       - equationalReasoning.md
       - laws.md
+
+algolia:
+  application_id: 'APP_ID'
+  index_name: 'csrg_index'


### PR DESCRIPTION
I've added [Algolia's Jekyll plugin](https://github.com/algolia/jekyll-algolia) so that we could search through the entire notes posted on the website. 

I've tested this in a fork of [csrgg-home](https://github.com/tomasff/csrgg-home) and it would look like this:
![UI](https://i.imgur.com/jTQdpYj.png)

I modified the current GH Actions to update the index when the site is built too, although I haven't been able to test the changes.

You'd need to setup an index in Algolia to get an API key and the other credentials. They have a free plan that should be enough (10k search results/month). We might be able to get more search results per month using [Algolia for Open Source](https://www.algolia.com/for-open-source/)

This is related to [this](https://github.com/CSRG-Group/csrgg-home/pull/1) PR.