### PR TITLE
CS132: PC should only be increased once

### DIFF
--- a/_CS132/part3.md
+++ b/_CS132/part3.md
@@ -35,7 +35,7 @@ A typical instruction cycle may look something like this:
 
 | Fetch                                                        | Decode                                                       | Execute                                                      |
 | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| 1. Instruction Received from memory location in PC<br />2. Retrieved instruction stored in IR<br />3. PC incremented to point to next instruction in memory | 1. Opcode retrieved / instruction decoded<br />2. Read effective address to establish opcode type | 1. CU signals functional CPU components<br />2. Can result in changes to data registers, such as the PC etc.<br />3. PC incremented to point to next instruction in memory |
+| 1. Instruction Received from memory location in PC<br />2. Retrieved instruction stored in IR<br />3. PC incremented to point to next instruction in memory | 1. Opcode retrieved / instruction decoded<br />2. Read effective address to establish opcode type | 1. CU signals functional CPU components<br />2. Can result in changes to data registers, such as the PC etc. |
 
 ## Registers
 


### PR DESCRIPTION
In the CS132 notes, the FDE cycle increments the PC twice.